### PR TITLE
Release/v0.0.8

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,6 +20,8 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v3.2.0
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,44 +1,49 @@
 name: build-and-push-docker-image
 
 on:
-    push:
-        tags:
-          - "v*.*.*"
+  push:
+    branches:
+      - release/*
+    tags:
+      - "v*.*.*"
 
 env:
-    GITHUB_REGISTRY: ghcr.io
-    DOCKER_IMAGE: ${{ github.repository }}
-    DOCKER_BUILDKIT: 1
-    DOCKER_CLI_AGGREGATE: 1
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-    build-push-docker-image:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: checkout the repo
-              uses: actions/checkout@v4
-            - name: login to ghcr.io
-              run: echo "${{ secrets.TOKEN }}" | docker login -u ${{ github.actor }} --password-stdin ${{ env.GITHUB_REGISTRY }}
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: build and push docker image using buildx
-              run: |
-                docker buildx create --use
-                docker buildx inspect
-                docker buildx build \
-                --platform linux/amd64 \
-                -t ${{ env.GITHUB_REGISTRY }}/${{ github.repository_owner }}/elna-platform-infrastructure \
-                -f Dockerfile \
-                --push .
-            - name: Release
-              uses: actions/github-script@v7
-              with:
-                github-token: ${{ secrets.TOKEN }}
-                script: |
-                  await github.request(`POST /repos/elna-ai/elna-platform-infrastructure/releases`, {
-                    tag_name: "${{ github.ref }}",
-                    generate_release_note: true
-                  });
+  build-push-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.4.1
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1.3.3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - main
-      - release/*
     tags:
       - "v*.*.*"
-
+  pull_request:
+    branches: ["main"]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -40,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v6.4.1
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -49,4 +49,4 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: sdk
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-push-docker-image:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,13 +3,14 @@ name: build-and-push-docker-image
 on:
   push:
     branches:
+      - main
       - release/*
     tags:
       - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: sdk
 
 jobs:
   build-push-docker-image:


### PR DESCRIPTION
* Repo name changed to SDK, so public ghcr url will be ```ghcr.io/elna-ai/sdk:latest```
* Pipeline workflow changes
* Pipeline will run only on PR to main and try to build image (but will not push)
* Push the Image to CR only on the merge to main and tagging